### PR TITLE
Use IPC to send data to main process and persist

### DIFF
--- a/app/containers/FromScratch.jsx
+++ b/app/containers/FromScratch.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Codemirror from 'react-codemirror';
 
+var ipc = require('ipc');
+
 require('../../node_modules/react-codemirror/node_modules/codemirror/keymap/sublime.js');
 var remote = require('remote');
 var handleContent = remote.getGlobal('handleContent');
@@ -22,9 +24,8 @@ export default class FromScratch extends React.Component {
   }
 
   componentDidUpdate() {
-    // the following line, for some reason, causes pastes, tabs and newlines to appear double
-    // this saves the data to disk, so we do need it.
-    handleContent.write(this.state.content);
+    // https://github.com/atom/electron/blob/master/docs/api/ipc-renderer.md
+    ipc.send('asynchronous-message', this.state.content);
   }
 
   handleChange(newcontent) {

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ var app = require('app');
 var BrowserWindow = require('browser-window');
 var fs = require('fs');
 var JSONStorage = require('node-localstorage').JSONStorage;
+var ipc = require('ipc')
 
 require('electron-debug')();
 require('crash-reporter').start();
@@ -27,9 +28,16 @@ app.on('window-all-closed', function() {
   app.quit();
 });
 
-
 app.on('ready', function() {
   var windowState = nodeStorage.getItem('windowstate') || {};
+
+  // https://github.com/atom/electron/blob/master/docs/api/ipc-main.md
+  // latest docs seem to mention require('electron') which I couldn't get to work
+  // http://electron.atom.io/docs/v0.27.0/api/ipc-main-process/
+  ipc.on('asynchronous-message', function(event, arg) {
+    console.log('got message', arg);  // prints "ping"
+    handleContent.write(arg);
+  });
 
   var windowSettings = {
     title: 'FromScratch',


### PR DESCRIPTION
Honestly I gave up trying to figure out why directly (or well, using `remote.getGlobal`) using handleContent caused the double event. I've had good experiences using IPC in the past so I just tried to see if that worked, and the problem is gone :) 

So now IPC is used to send data over from the renderer process over to the main process which takes care of persisting.