### PR TITLE
Fix codemirror require path

### DIFF
--- a/app/assets/style/app.scss
+++ b/app/assets/style/app.scss
@@ -78,7 +78,7 @@ body {
 }
 
 
-@import "../../../node_modules/react-codemirror/node_modules/codemirror/lib/codemirror.css";
+@import "../../../node_modules/codemirror/lib/codemirror.css";
 @import "_cm-theme.scss";
 
 .CodeMirror-scroll { overflow-x:hidden !important;}

--- a/app/containers/FromScratch.jsx
+++ b/app/containers/FromScratch.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Codemirror from 'react-codemirror';
 
-require('../../node_modules/react-codemirror/node_modules/codemirror/keymap/sublime.js');
+require('../../node_modules/codemirror/keymap/sublime.js');
 var ipc = require('electron').ipcRenderer;
 var remote = require('electron').remote;
 var handleContent = remote.getGlobal('handleContent');

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react",
     "webpack",
     "scratchpad",
-    "coidemirror"
+    "codemirror"
   ],
   "homepage": "https://github.com/kilian/fromscratch",
   "devDependencies": {


### PR DESCRIPTION
DarwinMacBook-Pro.local 15.3.0 Darwin Kernel Version 15.3.0: Thu Dec 10 18:40:58 PST 2015; root:xnu-3248.30.4~1/RELEASE_X86_64 x86_64

to avoid:
$ npm run hot-server
...
ERROR in ./app/containers/FromScratch.jsx
Module not found: Error: Cannot resolve 'file' or 'directory' ../../node_modules/react-codemirror/node_modules/codemirror/keymap/sublime.js in /Users/isghe/development/fromscratch/app/containers
 @ ./app/containers/FromScratch.jsx 61:0-88

ERROR in ./~/css-loader!./~/sass-loader!./app/assets/style/app.scss
Module not found: Error: Cannot resolve 'file' or 'directory' ../../../node_modules/react-codemirror/node_modules/codemirror/lib/codemirror.css in /Users/isghe/development/fromscratch/app/assets/style
 @ ./~/css-loader!./~/sass-loader!./app/assets/style/app.scss 3:10-148