### PR TITLE
Added FileDescription version string to package

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,8 +18,9 @@ var shouldBuildAll = argv.all || false;
 var DEFAULT_OPTS = {
   dir: './',
   name: appName,
-  'version-string': {
+  win32metadata: {
     FileDescription: appName,
+    ProductName: appName
   },
   asar: shouldUseAsar,
   ignore: [

--- a/package.js
+++ b/package.js
@@ -18,6 +18,9 @@ var shouldBuildAll = argv.all || false;
 var DEFAULT_OPTS = {
   dir: './',
   name: appName,
+  'version-string': {
+    FileDescription: appName,
+  },
   asar: shouldUseAsar,
   ignore: [
     '/README.md',


### PR DESCRIPTION
Adding FileDescription as it compiles makes it so that, say on Windows, you create a shortcut to FromScratch.exe on your start menu or pin it to the taskbar (as I like to do), it shows the appropriate app name rather than the default of 'Electron'